### PR TITLE
node examples/browser.js fails: "Cannot find module './build/Release/lib.target/girepository.node'"

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,7 +2,6 @@
     'targets': [
         {
             'target_name': 'girepository',
-            'type': '<(library)',
             'sources': [
                 'src/init.cc',
                 'src/util.cc',

--- a/gir.js
+++ b/gir.js
@@ -5,10 +5,10 @@
  **/
 
 //import gir library and EventEmitter
-var gir = module.exports = require('./build/Release/lib.target/girepository.node'),
-    EventEmitter = require('events').EventEmitter;
-//var gir = module.exports = require('./build/Release/girepository.node'),
+//var gir = module.exports = require('./build/Release/lib.target/girepository.node'),
 //    EventEmitter = require('events').EventEmitter;
+var gir = module.exports = require('./build/Release/girepository'),
+    EventEmitter = require('events').EventEmitter;
 
 /******************************************************************************/
 


### PR DESCRIPTION
Fresh clone of commit 89b36fd

After `npm install`:

```
$ node examples/browser.js

module.js:340
    throw err;
          ^
Error: Cannot find module './build/Release/lib.target/girepository.node'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/home/miki/vcs/git/node-gir/gir.js:8:28)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:362:17)
```

It appears that the file 'girepository.node' isn't built, only the '.so' file.
From looking at http://nodejs.org/api/addons.html
The 'type' field in binding.gyp is rarely needed, see: https://github.com/TooTallNate/node-gyp/wiki/%22binding.gyp%22-files-out-in-the-wild
Also there is no need to add '.node' extension in require() in gir.js.
After correcting the path in gir.js, I could run the examples and tests without errors.

```
$ npm test
[...]
  ✔ 146 tests complete (45752ms)
  • 3 tests pending
```
